### PR TITLE
Fix elevation in kml output

### DIFF
--- a/gpshelper.py
+++ b/gpshelper.py
@@ -152,7 +152,7 @@ def generate_KML(gps_points):
         <LineString>
             <extrude>1</extrude>
             <tessellate>1</tessellate>
-            <altitudeMode>absoluto</altitudeMode>
+            <altitudeMode>absolute</altitudeMode>
             <coordinates> 
                 %s
             </coordinates>


### PR DESCRIPTION
Fix a typo that was causing the track to appear as a ground track in Google Earth.  (Permitted `altitudeMode`s are documented [here](https://developers.google.com/kml/documentation/altitudemode).)