### PR TITLE
Adding 4 dummy keys to allow exporting of Hero 9 telemetry data to gpx.

### DIFF
--- a/gopro2gpx/fourCC.py
+++ b/gopro2gpx/fourCC.py
@@ -370,7 +370,13 @@ labels = {
 		"FACE" : LabelEmpty,
 		"MTRX" : LabelEmpty,
 		"ORIN" : LabelEmpty,
-		"ORIO" : LabelEmpty
+		"ORIO" : LabelEmpty,
+
+		# hero 9 fix
+		"MSKP" : LabelEmpty,
+		"LRVO" : LabelEmpty,
+		"LRVS" : LabelEmpty,
+		"LSKP" : LabelEmpty
 }
 
 def Manage(klvdata):


### PR DESCRIPTION
Hero 9 has added 4 new FourCC tags. This update allows generation of gpx data from Hero 9.