### PR TITLE
Fixed deprecated array.array.fromstring() to frombytes()

### DIFF
--- a/gopro2gpx/gpmf.py
+++ b/gopro2gpx/gpmf.py
@@ -87,7 +87,7 @@ class Parser:
         main code that reads the points
         """
         data = array.array('b')
-        data.fromstring(data_raw)
+        data.frombytes(data_raw)
 
         offset = 0
         klvlist = []


### PR DESCRIPTION
`array.array.fromstring()` was renamed to `array.array.frombytes()` in Python 3.2 and the alias removed in Python 3.9.
This just fixes this one code.

Fixes #6 