### PR TITLE
Runnable with `python3 -m gopro2gpx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,25 @@ python setup.py install
 ffmpeg = /path/to/ffmpeg
 ffprobe = /path/to/ffprobe
 ```
- 4. Run it (skip bad points, show the labels debug, create `hero6.kml` and `hero6.gpx` files)
-
+ 4. The script can then be invoced with
  ```shell
-    % gopro2gpx -s -vvv samples/hero6.mp4 hero6
+ gopro2gpx
  ```
-5. Custom run
+ or
+ ```shell
+ python3 -m gopro2gpx
+ ```
+ (exchange `python3` with your specific python installation)
+
+ E.g. to run it on the example data (skip bad points, show the labels debug, create `hero6.kml` and `hero6.gpx` files):
+
+```shell
+gopro2gpx -s -vvv samples/hero6.mp4 hero6
 ```
-cd gopro2gpx
+5. With custom path for FFMPEG
+```
 export PATH=$PATH:/usr/local/opt/ffmpeg/bin
- python3 -m gopro2gpx.gopro2gpx -vvv samples/8/GH010159.MP4 output.bin
+gopro2gpx -vvv samples/8/GH010159.MP4 output.bin
 ```
 
 # Arguments and options

--- a/gopro2gpx/__init__.py
+++ b/gopro2gpx/__init__.py
@@ -1,1 +1,0 @@
-from .gopro2gpx import main

--- a/gopro2gpx/__main__.py
+++ b/gopro2gpx/__main__.py
@@ -1,0 +1,3 @@
+from .gopro2gpx import main
+
+main()

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     version = "0.1",
     packages = ['gopro2gpx'],
     entry_points = {
-        'console_scripts': ['gopro2gpx = gopro2gpx:main']
+        'console_scripts': ['gopro2gpx = gopro2gpx.__main__']
     }
 )


### PR DESCRIPTION
This makes it runnable with `python3 -m gopro2gpx` (was `python3 -m gopro2gpx.gopro2gpx`, which still works).
Also fixes the runtime warning (#10) when invoked the old way. The fix needed updating of the entrypoint.

The Readme was updated a bit to make it clearer how to run gopro2gpx.