### PR TITLE
Fix entrypoint definition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     version = "0.1",
     packages = ['gopro2gpx'],
     entry_points = {
-        'console_scripts': ['gopro2gpx = gopro2gpx.__main__']
+        'console_scripts': ['gopro2gpx = gopro2gpx.__main__:main']
     }
 )


### PR DESCRIPTION
For some combination of setuptools / Python version the entrypoint definition needs a specific function name, an executable module is not enough.
This PR just adds the function name in the entrypoint definition.

Closes #14, closes #16, closes #19