### PR TITLE
Use JSON output from ffprobe

### DIFF
--- a/gopro2gpx/gpmf.py
+++ b/gopro2gpx/gpmf.py
@@ -40,12 +40,14 @@ class Parser:
         if not os.path.exists(self.file):
             raise FileNotFoundError("Can't open %s" % self.file)
 
-        track_number, lineinfo = self.ffmtools.getMetadataTrack(self.file)
+        # track_number, lineinfo = self.ffmtools.getMetadataTrack(self.file)
+        track_number, stream = self.ffmtools.getMetadataTrackFromJSON(self.file)
         if not track_number:
             raise Exception("File %s doesn't have any metadata" % self.file)
 
         if self.verbose:
-            print("Working on file %s track %s (%s)" % (self.file, track_number, lineinfo))
+            # print("Working on file %s track %s (%s)" % (self.file, track_number, lineinfo))
+            print("Working on file %s track %s (%s)" % (self.file, track_number, stream))
         metadata_raw = self.ffmtools.getMetadata(track_number, self.file)
 
         if self.verbose == 2:


### PR DESCRIPTION
use JSON-output of ffprobe for parsing instead of Regex to parse to Human-readable ouput

(I'm new to python, go easy on me)

still getting the following error:

```
% gopro2gpx ../_samples/test.mp4 test    
Traceback (most recent call last):
  File "/Users/davisa/code/python/gopro2gpx/gopro2gpx-alyssa/bin/gopro2gpx", line 33, in <module>
    sys.exit(load_entry_point('gopro2gpx==0.1', 'console_scripts', 'gopro2gpx')())
  File "/Users/davisa/code/python/gopro2gpx/gopro2gpx-alyssa/bin/gopro2gpx", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/local/Cellar/python@3.9/3.9.4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/local/Cellar/python@3.9/3.9.4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 627, in _load_backward_compatible
  File "<frozen zipimport>", line 259, in load_module
  File "/Users/davisa/code/python/gopro2gpx/gopro2gpx-alyssa/lib/python3.9/site-packages/gopro2gpx-0.1-py3.9.egg/gopro2gpx/__main__.py", line 3, in <module>
  File "/Users/davisa/code/python/gopro2gpx/gopro2gpx-alyssa/lib/python3.9/site-packages/gopro2gpx-0.1-py3.9.egg/gopro2gpx/gopro2gpx.py", line 148, in main
  File "/Users/davisa/code/python/gopro2gpx/gopro2gpx-alyssa/lib/python3.9/site-packages/gopro2gpx-0.1-py3.9.egg/gopro2gpx/gpmf.py", line 60, in readFromMP4
  File "/Users/davisa/code/python/gopro2gpx/gopro2gpx-alyssa/lib/python3.9/site-packages/gopro2gpx-0.1-py3.9.egg/gopro2gpx/gpmf.py", line 99, in parseStream
  File "/Users/davisa/code/python/gopro2gpx/gopro2gpx-alyssa/lib/python3.9/site-packages/gopro2gpx-0.1-py3.9.egg/gopro2gpx/klvdata.py", line 34, in __init__
  File "/Users/davisa/code/python/gopro2gpx/gopro2gpx-alyssa/lib/python3.9/site-packages/gopro2gpx-0.1-py3.9.egg/gopro2gpx/fourCC.py", line 391, in Manage
  File "/Users/davisa/code/python/gopro2gpx/gopro2gpx-alyssa/lib/python3.9/site-packages/gopro2gpx-0.1-py3.9.egg/gopro2gpx/fourCC.py", line 133, in Build
TypeError: a bytes-like object is required, not 'NoneType'
```