### PR TITLE
More precise timestamp, to fix timedata at least from Gopro8

### DIFF
--- a/gopro2gpx/fourCC.py
+++ b/gopro2gpx/fourCC.py
@@ -8,7 +8,7 @@
 
 
 import struct
-import time
+from datetime import datetime
 import collections
 import copy
 
@@ -76,9 +76,9 @@ class Label_TypeUTimeStamp(LabelBase):
 
 	def Build(self, klvdata):
 		s = klvdata.rawdata.decode('utf-8', errors='replace')
-		# 'yymmddhhmmss.sss'
+		# 'yymmddhhmmss.ffffff'
 		fmt = '%y%m%d%H%M%S.%f'
-		return time.strptime(s, fmt)
+		return datetime.strptime(s, fmt)
 
 class LabelDVID(LabelBase):
 	def __init__(self):

--- a/gopro2gpx/gopro2gpx.py
+++ b/gopro2gpx/gopro2gpx.py
@@ -81,7 +81,7 @@ def BuildGPSPoints(data, skip=False):
                 
 
                 gpsdata = fourCC.GPSData._make(retdata)
-                p = gpshelper.GPSPoint(gpsdata.lat, gpsdata.lon, gpsdata.alt, datetime.fromtimestamp(time.mktime(GPSU)), gpsdata.speed)
+                p = gpshelper.GPSPoint(gpsdata.lat, gpsdata.lon, gpsdata.alt, GPSU, gpsdata.speed)
                 points.append(p)
                 stats['ok'] += 1
 


### PR DESCRIPTION
Should fix 
https://github.com/juanmcasillas/gopro2gpx/issues/17
https://github.com/juanmcasillas/gopro2gpx/issues/23

```
<trkpt lat="49.8247704" lon="18.2175811">
		<ele>223.71</ele>
		<time>2022-04-23T13:04:27.484000Z</time>
		<extensions>
		<gpxtpx:TrackPointExtension>
```