### PR TITLE
Call `main` directly to avoid double invocation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     version = "0.1",
     packages = ['gopro2gpx'],
     entry_points = {
-        'console_scripts': ['gopro2gpx = gopro2gpx.__main__:main']
+        'console_scripts': ['gopro2gpx = gopro2gpx.gopro2gpx:main']
     }
 )


### PR DESCRIPTION
The `console_scripts` configuration appears to be incorrect causing a double invocation of the main function.
The way this works is that the `__main__.py` file contains the following:
```
from .gopro2gpx import main

main()
```
This imports the `main` function symbol into the `__main__.py` namespace which is a callable symbol.
Next the module calls the symbol invoking the `main()` function. However, this is all happening at import stage.

The `gopro2gpx` entry point is configured in the following way (`setup.py`):
```
    entry_points = {
        'console_scripts': ['gopro2gpx = gopro2gpx.__main__:main']
    }
```
This both imports the module (`gopro2gpx.__main__`) causing main to be invoked during import, and then it explicitly calls the `main` function symbol (`console_scripts` needs to provide a callable). This results in a double invocation of the `main` function when invoked from the command line.

This PR invokes the originating `main()` definition in the module directly, for a 2x speed up. 😉