### PR TITLE
Add support for multiple input files

### DIFF
--- a/gopro2gpx/config.py
+++ b/gopro2gpx/config.py
@@ -40,7 +40,7 @@ class Config:
             self.version.major = int(m.group(1))
             self.version.medium = int(m.group(2))
             self.version.minor = int(m.group(3))
-        
+
 def setup_environment(args):
     """
     Setup ffmpeg environment and commandline arguments.
@@ -73,7 +73,7 @@ def setup_environment(args):
 
     # configure CLI arguments
     config.verbose = args.verbose
-    config.file = args.file
+    config.files = args.files
     config.outputfile = args.outputfile
     return config
 

--- a/gopro2gpx/gopro2gpx.py
+++ b/gopro2gpx/gopro2gpx.py
@@ -136,7 +136,7 @@ def parseArgs():
     parser.add_argument("-v", "--verbose", help="increase output verbosity", action="count")
     parser.add_argument("-b", "--binary", help="read data from bin file", action="store_true")
     parser.add_argument("-s", "--skip", help="Skip bad points (GPSFIX=0)", action="store_true", default=False)
-    parser.add_argument("file", help="Video file or binary metadata dump")
+    parser.add_argument("files", help="Video file or binary metadata dump", nargs='*')
     parser.add_argument("outputfile", help="output file. builds KML and GPX")
     args = parser.parse_args()
 
@@ -145,20 +145,26 @@ def parseArgs():
 def main():
     args = parseArgs()
     config = setup_environment(args)
-    parser = gpmf.Parser(config)
+    points = []
+    start_time = None
+    for member in config.files:
+        parser = gpmf.Parser(config)
 
-    if not args.binary:
-        data = parser.readFromMP4()
-    else:
-        data = parser.readFromBinary()
+        if not args.binary:
+            data = parser.readFromMP4(member)
+        else:
+            data = parser.readFromBinary(member)
 
-    # build some funky tracks from camera GPS
+        # build some funky tracks from camera GPS
 
-    points, start_time = BuildGPSPoints(data, skip=args.skip)
+        file_points, file_start_time = BuildGPSPoints(data, skip=args.skip)
+        if start_time is None:
+            start_time = file_start_time
+        points += file_points
 
-    if len(points) == 0:
-        print("Can't create file. No GPS info in %s. Exitting" % args.file)
-        sys.exit(0)
+        if len(points) == 0:
+            print("Can't create file. No GPS info in %s. Exitting" % args.files)
+            sys.exit(0)
 
     #kml = gpshelper.generate_KML(points)
     #with open("%s.kml" % args.outputfile , "w+") as fd:

--- a/gopro2gpx/gpmf.py
+++ b/gopro2gpx/gpmf.py
@@ -28,31 +28,30 @@ class Parser:
 
         # map some handy shortcuts
         self.verbose = config.verbose
-        self.file = config.file
         self.outputfile = config.outputfile
 
 
-    def readFromMP4(self):
+    def readFromMP4(self, in_file):
         """read data the metadata track from video. Requires FFMPEG wrapper.
            -vv creates a dump file with the  binary data called dump_track.bin
         """
 
-        if not os.path.exists(self.file):
-            raise FileNotFoundError("Can't open %s" % self.file)
+        if not os.path.exists(in_file):
+            raise FileNotFoundError("Can't open %s" % in_file)
 
         if not self.config.use_json_format:
-            track_number, lineinfo = self.ffmtools.getMetadataTrack(self.file)
+            track_number, lineinfo = self.ffmtools.getMetadataTrack(in_file)
         else:
-            track_number, stream = self.ffmtools.getMetadataTrackFromJSON(self.file)
+            track_number, stream = self.ffmtools.getMetadataTrackFromJSON(in_file)
         if not track_number:
-            raise Exception("File %s doesn't have any metadata" % self.file)
+            raise Exception("File %s doesn't have any metadata" % in_file)
 
         if self.verbose:
             try:
-                print("Working on file %s track %s (%s)" % (self.file, track_number, stream))
+                print("Working on file %s track %s (%s)" % (in_file, track_number, stream))
             except UnboundLocalError:
-                print("Working on file %s track %s (%s)" % (self.file, track_number, lineinfo))
-        metadata_raw = self.ffmtools.getMetadata(track_number, self.file)
+                print("Working on file %s track %s (%s)" % (in_file, track_number, lineinfo))
+        metadata_raw = self.ffmtools.getMetadata(track_number, in_file)
 
         if self.verbose == 2:
             print("Creating output file for binary data (fromMP4): %s" % self.outputfile)
@@ -64,17 +63,17 @@ class Parser:
         metadata = self.parseStream(metadata_raw)
         return(metadata)
 
-    def readFromBinary(self):
+    def readFromBinary(self, in_file):
         """read data from binary file, instead extract the metadata track from video. Useful for quick development
            -vv creates a dump file with the  binary data called dump_binary.raw
         """
-        if not os.path.exists(self.file):
-            raise FileNotFoundError("Can't open %s" % self.file)
+        if not os.path.exists(in_file):
+            raise FileNotFoundError("Can't open %s" % in_file)
 
         if self.verbose:
-            print("Reading binary file %s" % (self.file))
+            print("Reading binary file %s" % (in_file))
 
-        fd = open(self.file, 'rb')
+        fd = open(in_file, 'rb')
         data = fd.read()
         fd.close()
 
@@ -106,12 +105,12 @@ class Parser:
                 if self.verbose == 3:
                     print(klv)
             else:
-                if klv: 
+                if klv:
                     print("Warning, skipping klv", klv)
                 else:
                     # unknown label
                     pass
-                    
+
             offset += 8
             if klv.type != 0:
                 offset += klv.padded_length


### PR DESCRIPTION
Should resolve #26.

This PR add support to gopro2gpx for multiple input files. Input files can be supplied as a list in place of the original single file specification. Each file is opened in sequence and the output GPX data collated into a single output file. Start time of the GPX is determined from the first input, so if the files are not sequential from the first file, timestamps may not make sense.

Example invocation:
```
gopro2gpx -s -vv max/GS010188.LRV max/GS020188.LRV max/GS030188.LRV max/GS040188.LRV max/GS050188.LRV track_gps_combined
```