### PR TITLE
Refactor ffmpegtools to reduce dependency linkage

### DIFF
--- a/gopro2gpx/config.py
+++ b/gopro2gpx/config.py
@@ -13,68 +13,38 @@ import sys
 import subprocess
 import re
 
-class E:
-    def __init__(self):
-        pass
-
 class Config:
-    def __init__(self, ffmpeg, ffprobe):
-        self.ffmpeg_cmd = ffmpeg
-        self.ffprobe_cmd = ffprobe
-        # get ffmpeg version
-        self.version = E()
-        self.version.major = 4
-        self.version.medium = 3
-        self.version.minor = 1
-        self.getFfmpegVersion()
-        self.use_json_format = False
-        if self.version.medium >= 4:
-            self.use_json_format = True
+    def __init__(self, verbose=0, outputfile=None):
+        self.ffmpeg_cmd = None
+        self.ffprobe_cmd = None
+        self.verbose = verbose
+        self.outputfile = outputfile
 
-    def getFfmpegVersion(self):
-        result = subprocess.run([ self.ffmpeg_cmd ] + ['-version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        version_info = result.stdout.decode('utf-8')
-        version_info_reg = re.compile('ffmpeg version (\d+)\.(\d+)\.(\d+)', flags=re.I)
-        m = version_info_reg.search(version_info)
-        if m and len(m.groups()) == 3:
-            self.version.major = int(m.group(1))
-            self.version.medium = int(m.group(2))
-            self.version.minor = int(m.group(3))
+    def load_config_file(self):
+        """
+        Load config file to check for ffmpeg path overrides
+        """
+        windows = platform.system() == 'Windows'
+        # find config path depending on OS
+        if windows:
+            config_path = os.path.expandvars(r"%APPDATA%\gopro2gpx\gopro2gpx.conf")
+        else:
+            if os.environ.get('XDG_CONFIG_HOME', False):
+                config_path = os.path.expandvars("$XDG_CONFIG_HOME/gopro2gpx.conf")
+            else:
+                config_path = os.path.expandvars("$HOME/.config/gopro2gpx.conf")
+
+        # read config if it exists
+        if os.path.exists(config_path):
+            conf = configparser.ConfigParser()
+            conf.read(config_path)
+            self.ffmpeg_cmd, self.ffprobe_cmd = conf["ffmpeg"]["ffmpeg"], conf["ffmpeg"]["ffprobe"]
+
 
 def setup_environment(args):
-    """
-    Setup ffmpeg environment and commandline arguments.
-    First check for config file, if it doesn't exist ffmpeg is assumed to be installed
-    somewhere in PATH
-    """
-    windows = platform.system() == 'Windows'
-    # find config path depending on OS
-    if windows:
-        config_path = os.path.expandvars(r"%APPDATA%\gopro2gpx\gopro2gpx.conf")
-    else:
-        if os.environ.get('XDG_CONFIG_HOME', False):
-            config_path = os.path.expandvars("$XDG_CONFIG_HOME/gopro2gpx.conf")
-        else:
-            config_path = os.path.expandvars("$HOME/.config/gopro2gpx.conf")
+    config = Config(verbose=args.verbose, outputfile=args.outputfile)
+    config.load_config_file()
 
-    # read config if it exists
-    if os.path.exists(config_path):
-        conf = configparser.ConfigParser()
-        conf.read(config_path)
-        ffmpeg, ffprobe = conf["ffmpeg"]["ffmpeg"], conf["ffmpeg"]["ffprobe"]
-    else:
-        # otherwise assume ffmpeg and ffprobe are in path
-        if windows:
-            ffmpeg, ffprobe = "ffmpeg.exe", "ffprobe.exe"
-        else:
-            ffmpeg, ffprobe = "ffmpeg", "ffprobe"
-
-    config = Config(ffmpeg, ffprobe)
-
-    # configure CLI arguments
-    config.verbose = args.verbose
-    config.files = args.files
-    config.outputfile = args.outputfile
     return config
 
 

--- a/gopro2gpx/ffmpegtools.py
+++ b/gopro2gpx/ffmpegtools.py
@@ -1,5 +1,5 @@
 #
-# 17/02/2019 
+# 17/02/2019
 # Juan M. Casillas <juanm.casillas@gmail.com>
 # https://github.com/juanmcasillas/gopro2gpx.git
 #
@@ -9,11 +9,44 @@
 import subprocess
 import re
 import json
+import platform
+from collections import namedtuple
+
+Version = namedtuple('Version', ['major', 'medium', 'minor'])
+
+def default_fftools():
+    if platform.system() == 'Windows':
+        ffmpeg, ffprobe = "ffmpeg.exe", "ffprobe.exe"
+    else:
+        ffmpeg, ffprobe = "ffmpeg", "ffprobe"
+
+    return ffmpeg, ffprobe
+
 
 class FFMpegTools:
 
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, ffprobe=None, ffmpeg=None):
+        default_ffmpeg, default_ffprobe = default_fftools()
+
+        self.ffmpeg = ffmpeg if ffmpeg else default_ffmpeg
+        self.ffprobe = ffprobe if ffprobe else default_ffprobe
+
+        self.version = self.getVersion()
+
+        self.use_json_format = False
+        if self.version.major >= 4:
+            self.use_json_format = True
+
+    def getVersion(self):
+        output = self.runCmdRaw(self.ffmpeg, ['-version'])
+        version_info = output.decode('utf-8')
+        version_info_reg = re.compile('ffmpeg version (\d+)\.(\d+)\.(\d+)', flags=re.I)
+        m = version_info_reg.search(version_info)
+        if m and len(m.groups()) == 3:
+            major = int(m.group(1))
+            medium = int(m.group(2))
+            minor = int(m.group(3))
+        return Version(major, medium, minor)
 
     def runCmd(self, cmd, args):
         result = subprocess.run([ cmd ] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -25,9 +58,15 @@ class FFMpegTools:
         output = result.stdout
         return output
 
-    def getMetadataTrackFromJSON(self, fname):
-        """ 
-            % ffprobe -print_format json -show_streams video.mp4 
+    def getMetadataTrack(self, fname):
+        if self.use_json_format:
+            return self._getMetadataTrackFromJSON(fname)
+        else:
+            return self._getMetadataTrackFromText(fname)
+
+    def _getMetadataTrackFromJSON(self, fname):
+        """
+            % ffprobe -print_format json -show_streams video.mp4
             % ffprobe -v quiet -print_format json -show_format -show_streams video.mp4"
 
             {
@@ -94,14 +133,15 @@ class FFMpegTools:
         """
         args = ['-print_format', 'json', '-show_streams', fname]
 
-        md = json.loads(self.runCmdRaw(self.config.ffprobe_cmd, args))
+        md = json.loads(self.runCmdRaw(self.ffprobe, args))
         stream = next((stream for stream in md['streams'] if stream['codec_tag_string'] == 'gpmd'), None)
 
         if not stream:
-            return(None)
-        return(int(stream["index"]), stream)
+            return None, None
+        info_string = 'Stream {}[{}], {} ({})'.format(stream['index'], stream['id'], stream['codec_name'], stream['codec_tag_string'])
+        return int(stream["index"]), info_string
 
-    def getMetadataTrack(self, fname):
+    def _getMetadataTrackFromText(self, fname):
         """
         % ffprobe GH010039.MP4 2>&1
 
@@ -113,22 +153,22 @@ class FFMpegTools:
             Stream #0:2(eng): Data: none (tmcd / 0x64636D74), 0 kb/s (default)
             Stream #0:3(eng): Data: none (gpmd / 0x646D7067), 29 kb/s (default)
             Stream #0:4(eng): Data: none (fdsc / 0x63736466), 12 kb/s (default)
-        """      
-        output = self.runCmd(self.config.ffprobe_cmd, [fname])
+        """
+        output = self.runCmd(self.ffprobe, [fname])
         # Stream #0:3(eng): Data: bin_data (gpmd / 0x646D7067), 29 kb/s (default)
         # Stream #0:2(eng): Data: none (gpmd / 0x646D7067), 29 kb/s (default)
         # Stream #0:3[0x4](eng): Data: bin_data (gpmd
         reg = re.compile('Stream #\d:(\d)(?:\[0x\d+\])?\(.+\): Data: \w+ \(gpmd', flags=re.I|re.M)
-        
+
         m = reg.search(output)
-        
+
         if not m:
-            return(None)
-        return(int(m.group(1)), m.group(0))
+            return None, None
+        return int(m.group(1)), m.group(0)
 
     def getMetadata(self, track, fname):
 
         output_file = "-"
-        args = [ '-y', '-i', fname, '-codec', 'copy', '-map', '0:%d' % track, '-f', 'rawvideo', output_file ] 
-        output = self.runCmdRaw(self.config.ffmpeg_cmd, args)
+        args = [ '-y', '-i', fname, '-codec', 'copy', '-map', '0:%d' % track, '-f', 'rawvideo', output_file ]
+        output = self.runCmdRaw(self.ffmpeg, args)
         return(output)

--- a/gopro2gpx/gopro2gpx.py
+++ b/gopro2gpx/gopro2gpx.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from datetime import datetime
 
 from .config import setup_environment
+from .ffmpegtools import FFMpegTools
 from . import fourCC
 from . import gpmf
 from . import gpshelper
@@ -147,13 +148,14 @@ def main():
     config = setup_environment(args)
     points = []
     start_time = None
-    for member in config.files:
-        parser = gpmf.Parser(config)
+    ffmpegtools = FFMpegTools(ffprobe=config.ffprobe_cmd, ffmpeg=config.ffmpeg_cmd)
+    for filename in args.files:
+        parser = gpmf.Parser(config, ffmpegtools)
 
         if not args.binary:
-            data = parser.readFromMP4(member)
+            data = parser.readFromMP4(filename)
         else:
-            data = parser.readFromBinary(member)
+            data = parser.readFromBinary(filename)
 
         # build some funky tracks from camera GPS
 

--- a/gopro2gpx/gpmf.py
+++ b/gopro2gpx/gpmf.py
@@ -17,14 +17,13 @@ import os
 import struct
 import sys
 
-from .ffmpegtools import FFMpegTools
 from .klvdata import KLVData
 
 
 class Parser:
-    def __init__(self, config):
+    def __init__(self, config, ffmpegtools):
         self.config = config
-        self.ffmtools = FFMpegTools(self.config)
+        self.ffmtools = ffmpegtools
 
         # map some handy shortcuts
         self.verbose = config.verbose
@@ -39,18 +38,13 @@ class Parser:
         if not os.path.exists(in_file):
             raise FileNotFoundError("Can't open %s" % in_file)
 
-        if not self.config.use_json_format:
-            track_number, lineinfo = self.ffmtools.getMetadataTrack(in_file)
-        else:
-            track_number, stream = self.ffmtools.getMetadataTrackFromJSON(in_file)
+        track_number, info = self.ffmtools.getMetadataTrack(in_file)
+
         if not track_number:
             raise Exception("File %s doesn't have any metadata" % in_file)
 
         if self.verbose:
-            try:
-                print("Working on file %s track %s (%s)" % (in_file, track_number, stream))
-            except UnboundLocalError:
-                print("Working on file %s track %s (%s)" % (in_file, track_number, lineinfo))
+            print("Working on file %s track %s (%s)" % (in_file, track_number, info))
         metadata_raw = self.ffmtools.getMetadata(track_number, in_file)
 
         if self.verbose == 2:
@@ -71,7 +65,7 @@ class Parser:
             raise FileNotFoundError("Can't open %s" % in_file)
 
         if self.verbose:
-            print("Reading binary file %s" % (in_file))
+            print("Reading binary file %s" % in_file)
 
         fd = open(in_file, 'rb')
         data = fd.read()


### PR DESCRIPTION
This PR refactors some of the classes to reduce direct dependencies between them. I'll summarize the changes below.
Note, these changes are structural and should be largely invisible. The only exception to this is the information string (previously `stream`) when using `getMetadataTrack` with json.

### `config.py`

Relocate ffmpeg version logic from `config.py` to `ffmpegtools.py`. This file just queries the config file if it exists and stores the ffprobe and ffmpeg paths if available. This removes ffmpeg specific operations from the concerns of `config.py`.

### `ffmpegtools.py`

Remove the dependency and internal knowledge of the `Config` class from the `FFMpegTools` class. This class now conditionally overrides the ffprobe and ffmpeg paths if provided, otherwise with initialize itself with sensible defaults (based on the plaform). Additionally, this allows for the determination of whether to use the ffprobe json interface to be internal to the `FFMpegTools` class. This allows for the `getMetadataTrackFromJSON` and `getMetadataTrack` methods to be removed and combined into a single method `getMetadataTrack` which uses the json interface as needed. This simplifies the use of the class in the `gpmf.py` classes.

### `gopro2gpx.py`

The `FFMpegTools` class is instantiated at the top-level `main()` function so that it can be injected into the `Parser` class rather than have it be instantiated inline. This should make the `Parser` class easier to test as we can mock the `FFMpegTools` class.

### `gpmf.py`

This now takes the injected `FFMpegTools` dependency. There is now only a unified method `getMetadataTrack` to call so the conditional has been removed.