### PR TITLE
Fix binary file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ My idea is process the file in python, extract the data, and build a file in a k
 # Installation
 
 1. Package installation: there are two ways to install the package:
+
    a) Install via pip (with git installed):
-   
+
    ```
    pip install git+https://github.com/juanmcasillas/gopro2gpx
    ```
-   
+
    b) *Or* Download the repository, unpack it and instal with
-   
+
    ```
    python setup.py install
    ```
@@ -50,14 +51,14 @@ My idea is process the file in python, extract the data, and build a file in a k
 2. Ensure you have **FFmpeg** and **FFprobe** installed in your system.
 
 3. If ffmpeg is not installed in a `PATH` location, the path can be specified in the config file.
-   
+
    The configuration file is located in:
-   
+
    - Windows: `%APPDATA%\gopro2gpx\gopro2gpx.conf`
    - Unix (Linux, Mac): `$HOME/.config/gopro2gpx.conf` (`$XDG_CONFIG_HOME/gopro2gpx.conf` to be exact)
-   
+
    The configuration file has to look like this:
-   
+
    ```
    [ffmpeg]
    ffmpeg = /path/to/ffmpeg
@@ -65,27 +66,27 @@ My idea is process the file in python, extract the data, and build a file in a k
    ```
 
 4. The script can then be invoked with
-   
+
    ```shell
    gopro2gpx
    ```
-   
+
    or
-   
+
    ```shell
    python3 -m gopro2gpx
    ```
-   
+
    (exchange `python3` with your specific python installation)
-   
+
    E.g. to run it on the example data (skip bad points, show the labels debug, create `hero6.kml` and `hero6.gpx` files):
-   
+
    ```shell
    gopro2gpx -s -vvv samples/hero6.mp4 hero6
    ```
 
 5. With custom path for FFMPEG
-   
+
    ```
    export PATH=$PATH:/usr/local/opt/ffmpeg/bin
    gopro2gpx -vvv samples/8/GH010159.MP4 output.bin

--- a/README.md
+++ b/README.md
@@ -36,46 +36,60 @@ My idea is process the file in python, extract the data, and build a file in a k
 
 1. Package installation: there are two ways to install the package:
    a) Install via pip (with git installed):
-```
-pip install git+https://github.com/juanmcasillas/gopro2gpx
-```
+   
+   ```
+   pip install git+https://github.com/juanmcasillas/gopro2gpx
+   ```
+   
    b) *Or* Download the repository, unpack it and instal with
-```
-python setup.py install
-```
-2. Ensure you have **FFmpeg** and **FFprobe** installed in your system.
-3. If ffmpeg is not installed in a `PATH` location, the path can be specified in the config file.
+   
+   ```
+   python setup.py install
+   ```
 
+2. Ensure you have **FFmpeg** and **FFprobe** installed in your system.
+
+3. If ffmpeg is not installed in a `PATH` location, the path can be specified in the config file.
+   
    The configuration file is located in:
+   
    - Windows: `%APPDATA%\gopro2gpx\gopro2gpx.conf`
    - Unix (Linux, Mac): `$HOME/.config/gopro2gpx.conf` (`$XDG_CONFIG_HOME/gopro2gpx.conf` to be exact)
-
+   
    The configuration file has to look like this:
-```
-[ffmpeg]
-ffmpeg = /path/to/ffmpeg
-ffprobe = /path/to/ffprobe
-```
- 4. The script can then be invoced with
- ```shell
- gopro2gpx
- ```
- or
- ```shell
- python3 -m gopro2gpx
- ```
- (exchange `python3` with your specific python installation)
+   
+   ```
+   [ffmpeg]
+   ffmpeg = /path/to/ffmpeg
+   ffprobe = /path/to/ffprobe
+   ```
 
- E.g. to run it on the example data (skip bad points, show the labels debug, create `hero6.kml` and `hero6.gpx` files):
+4. The script can then be invoked with
+   
+   ```shell
+   gopro2gpx
+   ```
+   
+   or
+   
+   ```shell
+   python3 -m gopro2gpx
+   ```
+   
+   (exchange `python3` with your specific python installation)
+   
+   E.g. to run it on the example data (skip bad points, show the labels debug, create `hero6.kml` and `hero6.gpx` files):
+   
+   ```shell
+   gopro2gpx -s -vvv samples/hero6.mp4 hero6
+   ```
 
-```shell
-gopro2gpx -s -vvv samples/hero6.mp4 hero6
-```
 5. With custom path for FFMPEG
-```
-export PATH=$PATH:/usr/local/opt/ffmpeg/bin
-gopro2gpx -vvv samples/8/GH010159.MP4 output.bin
-```
+   
+   ```
+   export PATH=$PATH:/usr/local/opt/ffmpeg/bin
+   gopro2gpx -vvv samples/8/GH010159.MP4 output.bin
+   ```
 
 # Arguments and options
 
@@ -96,7 +110,11 @@ optional arguments:
 
 * `file`: Gopro MP4 file or binary file with the gpmd dump.
 * `outputfile`: Dump the GPS info into `outputfile.kml` and `outputfile.gpx`. Don't use extension.
-* `-v`, `-vv`, `-vvv`: Verbose mode. First show some info, second dumps the `gpmd` track info a file called `outputfile.bin` and third (`-vvv`) shows the labels.
+* `-v`, `-vv`, `-vvv`: Verbose mode.
+  * Level 1 (`-v`) - show addition info
+  * Level 2 (`-vv`) - dumps the `gpmd` track info files called `<outputfile>.XX.bin`
+    * Here `XX` is an integer: `00`, `01`, `02`, etc, indicating this binary is from the zero offset n-th input file
+  * Level 3 (`-vvv`) - shows the low-level parsing label data
 * `-b`: read the data from a binary dump fo the gpmd track istead of the MP4 video. Useful for testing, so I don't need to move big MP4 files.
 * `-s`: skip "bad" GPS points. When `GPSFIX=0` (no GPS satellite signal received) GPS data is unacurrate. Ignore these points.
 
@@ -109,6 +127,7 @@ Follow these steps:
 3. Use the camera in the Frame mount and not the Super Suit (it will work in the Super Suit but might have a weaker signal)
 
 Read the following thread for more info:
+
 * [GOPRO Forum](https://community.gopro.com/t5/GoPro-Apps-for-Desktop/GPS-data-all-wrong/td-p/200091?profile.language=es)
 
 # Technical info
@@ -219,6 +238,7 @@ please extract the raw data and send me them (see [extracting data](#extracting-
 
 [Pytest](https://docs.pytest.org/) test harnesses exist in the `test` directory. With pytest installed, these can be run by using the following
 command in the top-level project directory:
+
 ```sh
 pytest
 ```
@@ -232,6 +252,3 @@ Currently, `gopro2gpx` generates *hard-formatted* `kml`, and a useful `gpx` file
 - Karma drone GPS info has been infered from debug. Maybe the `SYST` label is parsed wrong.
 - `UNIT` labels are parsed hardcoded.
 - Need `ffmpeg` and `ffprobe` to extract the data.
-
-
-

--- a/test/test_samples.py
+++ b/test/test_samples.py
@@ -41,7 +41,7 @@ def test_sample_set():
 
         expected_filename = samples_dir + sample_gpx
         result_gpx_filename = dir_path + output_file_prefix + '.gpx'
-        result_bin_filename = dir_path + output_file_prefix + '.raw'
+        result_bin_filename = dir_path + output_file_prefix + '.00.bin'
 
         gopro2gpx.main_core(args)
 


### PR DESCRIPTION
This PR fixes an issue related to the introduction of multiple input file handling (#33). With the introduction of multiple input files, the output binary file gets overwritten multiple times as the same output file name is used for all input files in the stream.

The core issue is that the binary file generation is done as a side effect of the `readFrom...` methods in the `Parser` class. This class in the past used the output file information for the target bin file, however, this doesn't really work once we have to generate multiple bin files as the output information doesn't correlate to the input file set as it did when there was just one input file. The fact that the Parser class implicitly generates binaries as a side effect makes a bit awkward as input file information isn't available in this class.

To resolve this, this PR reorganizes the top-level loop in `gopro2gpx.main_core` to do the following:

1. Pull the binary generation up to the top-level allowing for the binary generation to be based on input file information rather than output file specification
2. Allow for all reading of input files to happen prior before any GPS generation occurs, aggregating the data into a single KLV block. This allows the data to be processed as a single contiguous block, which is more natural way of processing this data. This also eliminates the need to pass any information between invocations of `BuildGPSPoints` (e.g start_time) when processing multiple files. 

In the `gpmf.py` module, the dependencies on the `config.py` class had been reduced to just the verbose variable, so this has been made an explicit parameter to the internals of this module. This should simplify testing.
Inside the `gpmf.py` module, the Parser class has been broken out into the following code:

- GpmfFileReader class
  - This class deals just with the transformation of a file (MP4 or binary) into a metadata stream
- parseStream function
  - This deals with transforming a metadata stream into a KLV record list
  - This had no other dependencies to the rest of the module code, so could be a stand alone function which should assist with building unit tests

The README.md file and tests have been updated to match these changes