### PR TITLE
Gopro11 Black update for Handling 2 datatypes

### DIFF
--- a/gopro2gpx/gopro2gpx.py
+++ b/gopro2gpx/gopro2gpx.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python
 #
 # 17/02/2019
@@ -25,6 +26,7 @@ from .ffmpegtools import FFMpegTools
 from . import fourCC
 from . import gpmf
 from . import gpshelper
+from . import VERSION
 
 
 def BuildGPSPoints(data, skip=False, skipDop=False, dopLimit=2000):
@@ -213,6 +215,7 @@ def BuildGPSPoints(data, skip=False, skipDop=False, dopLimit=2000):
     return(points, start_time, DVNM)
 
 def parseArgs():
+    version_text = f"gopro2gpx version {VERSION}"
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose", help="increase output verbosity", action="count")
     parser.add_argument("-b", "--binary", help="read data from bin file", action="store_true")
@@ -222,6 +225,12 @@ def parseArgs():
     parser.add_argument("--gpx", help="Generate only GPX output", action="store_true", default=False)
     parser.add_argument("--kml", help="Generate only KML output", action="store_true", default=False)
     parser.add_argument("--csv", help="Generate only CSV output", action="store_true", default=False)
+    parser.add_argument(
+        "--version",
+        help="show the gopro2gpx version and exit",
+        action="version",
+        version=version_text,
+    )
     parser.add_argument("files", help="Video file or binary metadata dump", nargs='+')
     parser.add_argument("outputfile", help="output file prefix. Builds KML, GPX and CSV by default")
     args = parser.parse_args()

--- a/gopro2gpx/gopro2gpx.py
+++ b/gopro2gpx/gopro2gpx.py
@@ -25,7 +25,7 @@ from .ffmpegtools import FFMpegTools
 from . import fourCC
 from . import gpmf
 from . import gpshelper
-from . import VERSION
+
 
 def BuildGPSPoints(data, skip=False, skipDop=False, dopLimit=2000):
     """
@@ -122,7 +122,7 @@ def BuildGPSPoints(data, skip=False, skipDop=False, dopLimit=2000):
 
 
                 gpsdata = fourCC.GPSData._make(retdata)
-                p = gpshelper.GPSPoint(gpsdata.lat, gpsdata.lon, gpsdata.alt, GPSU + datetime.timedelta(seconds= sample_count * t_delta), gpsdata.speed)
+                p = gpshelper.GPSPoint(gpsdata.lat, gpsdata.lon, gpsdata.alt, GPSU + datetime.timedelta(seconds= sample_count * t_delta), gpsdata.speed,'GPS5')
                 points.append(p)
                 stats['ok'] += 1
                 sample_count += 1
@@ -158,7 +158,7 @@ def BuildGPSPoints(data, skip=False, skipDop=False, dopLimit=2000):
                 gps_time = target_date + time_of_day
                 if start_time is None:
                     start_time = gps_time
-                p = gpshelper.GPSPoint(gpsdata.lat, gpsdata.lon, gpsdata.alt, gps_time, gpsdata.speed)
+                p = gpshelper.GPSPoint(gpsdata.lat, gpsdata.lon, gpsdata.alt, gps_time, gpsdata.speed,'GPS9')
                 points.append(p)
                 stats['ok'] += 1
 
@@ -213,7 +213,6 @@ def BuildGPSPoints(data, skip=False, skipDop=False, dopLimit=2000):
     return(points, start_time, DVNM)
 
 def parseArgs():
-    version_text = f"gopro2gpx version {VERSION}"
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose", help="increase output verbosity", action="count")
     parser.add_argument("-b", "--binary", help="read data from bin file", action="store_true")
@@ -223,12 +222,6 @@ def parseArgs():
     parser.add_argument("--gpx", help="Generate only GPX output", action="store_true", default=False)
     parser.add_argument("--kml", help="Generate only KML output", action="store_true", default=False)
     parser.add_argument("--csv", help="Generate only CSV output", action="store_true", default=False)
-    parser.add_argument(
-        "--version",
-        help="show the gopro2gpx version and exit",
-        action="version",
-        version=version_text,
-    )
     parser.add_argument("files", help="Video file or binary metadata dump", nargs='+')
     parser.add_argument("outputfile", help="output file prefix. Builds KML, GPX and CSV by default")
     args = parser.parse_args()

--- a/gopro2gpx/gpshelper.py
+++ b/gopro2gpx/gpshelper.py
@@ -15,7 +15,7 @@ import csv
 
 
 class GPSPoint:
-    def __init__(self, latitude=0.0, longitude=0.0, elevation=0.0, time=datetime.fromtimestamp(time.time()), speed=0.0):
+    def __init__(self, latitude=0.0, longitude=0.0, elevation=0.0, time=datetime.fromtimestamp(time.time()), speed=0.0,name=''):
         self.latitude = latitude
         self.longitude = longitude
         self.elevation = elevation
@@ -31,6 +31,7 @@ class GPSPoint:
         self.distance = 0
         self.left_pedal_smoothness = 0
         self.left_torque_effectiveness = 0
+        self.name = name
 
 
 def UTCTime(timedata):
@@ -61,6 +62,7 @@ def generate_CSV(points, start_time=None, trk_name="exercise"):
         "elevation",
         "time",
         "hr",
+        "name",
         "cadence",
         "speed",
         "distance",
@@ -77,6 +79,7 @@ def generate_CSV(points, start_time=None, trk_name="exercise"):
             p.elevation,
             UTCTime(p.time),
             p.hr,
+            p.name,
             p.cadence,
             p.speed,
             p.distance,
@@ -148,8 +151,10 @@ def generate_GPX(points, start_time=None, trk_name="exercise"):
         cadence = p.cad
         speed = p.speed
         distance = p.distance
+        fourcc_type = p.name
 
         pts  = '	<trkpt lat="%s" lon="%s">\r\n' % (p.latitude, p.longitude)
+        pts += '		<fourcc_type>%s</fourcc_type>\r\n' % fourcc_type
         pts += '		<ele>%s</ele>\r\n' % p.elevation
         pts += '		<time>%s</time>\r\n' % UTCTime(p.time)
         pts += '		<extensions>\r\n'


### PR DESCRIPTION
Current code provides a long list of telemetry data for Gopro11 model, because it has both GPS5 and GPS9 fourCC type for GPS data. It would be beneficial if the Gpx/Csv file specifies each attribute point is derived from which type  